### PR TITLE
Allow CadenceBot to work on multiple servers simultaneously

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -48,12 +48,12 @@ var bot=new Discord.Client({
     autorun: true
 });
 
-var isPlaying: {};
+var isPlaying={};
 
-var reconnectAllowedAt: {};
+var reconnectAllowedAt={};
 var reconnectTimeout=30; // Seconds
 
-var lastSearchedSongs: {};
+var lastSearchedSongs={};
 
 function command(message) {
     if (message.content===config.commands.play) {

--- a/bot.js
+++ b/bot.js
@@ -182,7 +182,7 @@ function command(message) {
         });
     }
     else if (message.content.startsWith(config.commands.search)) {
-        log.notice("Received search command in text channel "+message.channel.name", server "+message.guild.name+".");
+        log.notice("Received search command in text channel "+message.channel.name+", server "+message.guild.name+".");
         log.notice("Received message was \""+message.content+"\"");
         const url='http://cadenceradio.com/search';
         var data={
@@ -212,8 +212,8 @@ function command(message) {
                    message.reply(response);
                }
            }
-               log.error("Response is erroneous. Returned body:\n\n"+body+"\n\n");
            else {
+               log.error("Response is erroneous. Returned body:\n\n"+body+"\n\n");
                if (response) {
                    log.error("Returned status code: "+response.statusCode);
                    message.reply("Error "+response.statusCode+". Aria says:\n\n"+body);
@@ -226,7 +226,7 @@ function command(message) {
         });
     }
     else if (message.content.startsWith(config.commands.request)) {
-        log.notice("Received song request in text channel "+message.channel.name", server "+message.guild.name+".");
+        log.notice("Received song request in text channel "+message.channel.name+", server "+message.guild.name+".");
         log.notice("Received message was \""+message.content+"\"");
         log.debug("Last searched songs:\n\n"+JSON.stringify(lastSearchedSongs[message.channel.id])+"\n\n");
         lastSearchedSongs[message.channel.id]=lastSearchedSongs[message.channel.id] || []; // Default to empty array to avoid crash

--- a/bot.js
+++ b/bot.js
@@ -119,6 +119,7 @@ function command(message) {
                         msg.reply=function(r) {message.reply(r)};
                         msg.member={};
                         msg.member.voiceChannel=voiceChannel;
+                        msg.guild=message.guild;
                         log.notice("Sending mocked play command...");
                         command(msg);
                     });

--- a/bot.js
+++ b/bot.js
@@ -70,7 +70,7 @@ function command(message) {
                 isPlaying[message.guild.id]=true;
                 voiceChannel.join().then(connection => {
                     log.notice("Joined. Beginning playback (channel bitrate="+voiceChannel.bitrate+").");
-                    const dispatch = connection.playArbitraryInput('http://cadenceradio.com:8000/cadence1');
+                    const dispatch = connection.playArbitraryInput('http://cadenceradio.com:8000/cadence1', { 'bitrate': config.bitrate });
                     dispatch.on("end", end=> {
                         log.warning("Stream ended. Playback was in server "+message.guild.name+", channel "+voiceChannel.name);
                         if (!isPlaying[message.guild.id]) return;

--- a/bot.js
+++ b/bot.js
@@ -47,17 +47,18 @@ var bot=new Discord.Client({
     token: auth.token,
     autorun: true
 });
-var isPlaying=false;
 
-var reconnectAllowedAt=new Date();
+var isPlaying: {};
+
+var reconnectAllowedAt: {};
 var reconnectTimeout=30; // Seconds
 
-var lastSearchedSongs=[];
+var lastSearchedSongs: {};
 
 function command(message) {
     if (message.content===config.commands.play) {
         log.notice("Received play command.");
-        if (isPlaying) {
+        if (isPlaying[message.guild.id]) {
             log.info("Already playing.\n");
             message.reply("Don't you have enough Cadence already?");
         }
@@ -65,28 +66,30 @@ function command(message) {
             var voiceChannel=message.member.voiceChannel;
             if (voiceChannel) {
                 log.info("Attempting to join voice channel "+voiceChannel.name);
-                isPlaying=true;
+                reconnectAllowedAt[voiceChannel.id]=new Date();
+                isPlaying[message.guild.id]=true;
                 voiceChannel.join().then(connection => {
                     log.notice("Joined. Beginning playback (channel bitrate="+voiceChannel.bitrate+").");
                     const dispatch = connection.playArbitraryInput('http://cadenceradio.com:8000/cadence1');
                     dispatch.on("end", end=> {
                         log.warning("Stream ended. The current time is "+new Date().toString());
-			if (!isPlaying) return;
+                        if (!isPlaying[message.guild.id]) return;
 
                         log.warning("Error was: "+end);
 
-                        isPlaying=false;
-                        if (new Date()<reconnectAllowedAt) {
+                        isPlaying[message.guild.id]=false;
+                        if (new Date()<reconnectAllowedAt[voiceChannel.id]) {
                             log.notice("Before reconnect timer. Disconnecting");
                             message.reply("Since I've already tried to reconnect in the last "+reconnectTimeout+" seconds, I won't try again.\n\nRun \""+config.commands.play+"\" if you want me to try again.");
                             voiceChannel.leave();
                             return;
                         }
-                        reconnectAllowedAt=new Date();
-                        reconnectAllowedAt.setSeconds(reconnectAllowedAt.getSeconds()+reconnectTimeout);
+                        var rAA=new Date();
+                        rAA.setSeconds(rAA.getSeconds()+reconnectTimeout);
+                        reconnectAllowedAt[voiceChannel.id]=rAA;
 
                         message.reply("Hm, I seem to have lost Cadence.\n\nLet me see if I can get it back for you.");
-                        
+
                         // Issue a spurious nowplaying to get it in the log.
                         // Should remove this before sending to prod, probably
                         var msg={};
@@ -94,15 +97,15 @@ function command(message) {
                         msg.reply=function (s) {log.debug("Sent message: "+s)};
                         log.notice("Sending false nowplaying command...");
                         command(msg);
-                        
-                        // Now, we want to reissue ourselves a play command 
-                        //  equivalent to the original one, to begin playback on 
+
+                        // Now, we want to reissue ourselves a play command
+                        //  equivalent to the original one, to begin playback on
                         //  the same channel.
                         // At a glance, that means reissuing the original message.
                         // However, if the user has since disconnected...
                         //  ... We'll generate a spurious error.
                         // The play code wants to connect to the user's channel:
-                        // It doesn't know what channel to connect to if the user 
+                        // It doesn't know what channel to connect to if the user
                         //  isn't connected.
                         // We, however, do.
                         // So, if there isn't a VC, we need to mock it.
@@ -129,11 +132,11 @@ function command(message) {
     }
     else if (message.content===config.commands.stop) {
         log.notice("Received stop command.");
-        if (isPlaying) {
+        if (isPlaying[message.guild.id]) {
             log.info("Attempting to disconnect from channel.");
             var voiceChannel=message.member.voiceChannel;
             if (voiceChannel) {
-                isPlaying=false;
+                isPlaying[message.guild.id]=false;
                 voiceChannel.leave();
                 log.notice("Disconnected from channel "+voiceChannel.name+".");
             }
@@ -199,7 +202,7 @@ function command(message) {
                }
                else {
                    log.info(songs.length+" result(s).");
-                   lastSearchedSongs=songs;
+                   lastSearchedSongs[message.channel.id]=songs;
                    var response="Cadence returned:\n";
                    for (var i=0; i<songs.length; ++i) {
                        response+="  "+(i+1)+")  \""+songs[i].title+"\" by "+songs[i].artist[0]+"\n";
@@ -224,8 +227,9 @@ function command(message) {
     else if (message.content.startsWith(config.commands.request)) {
         log.notice("Received song request.");
         log.notice("Received message was \""+message.content+"\"");
-        log.debug("Last searched songs:\n\n"+JSON.stringify(lastSearchedSongs)+"\n\n");
-        if (lastSearchedSongs.length==0) {
+        log.debug("Last searched songs:\n\n"+JSON.stringify(lastSearchedSongs[message.channel.id])+"\n\n");
+        lastSearchedSongs[message.channel.id]=lastSearchedSongs[message.channel.id] || []; // Default to empty array to avoid crash
+        if (lastSearchedSongs[message.channel.id].length==0) {
             log.error("No stored results.");
             message.reply("Please search for your songs before requesting them.");
             return;
@@ -243,14 +247,14 @@ function command(message) {
             return;
         }
         log.notice("Prepared to construct request for song at index "+song);
-        if (song>=lastSearchedSongs.length) {
+        if (song>=lastSearchedSongs[message.channel.id].length) {
             log.error("Index out-of-bounds.");
-            message.reply("Sorry, I can't request song number "+(song+1)+" out of a set of "+lastSearchedSongs.length+".");
+            message.reply("Sorry, I can't request song number "+(song+1)+" out of a set of "+lastSearchedSongs[message.channel.id].length+".");
             return;
         }
 
         var data={
-            path: lastSearchedSongs[song].path
+            path: lastSearchedSongs[message.channel.id][song].path
         };
         log.info("Making a request to "+url);
         log.debug("data.path="+data.path);
@@ -260,7 +264,7 @@ function command(message) {
                 log.notice("Request received. Clearing lastSearchedSongs...");
                 log.info("Aria says: "+body);
                 message.reply("Your request has been received.");
-                lastSearchedSongs=[];
+                lastSearchedSongs[message.channel.id]=[];
             }
             else if (response) {
                 if (response.statusCode==429) {
@@ -285,6 +289,10 @@ function command(message) {
 
 bot.on('message', message => {
     command(message)
+});
+
+bot.on('guildCreate', guild => {
+    isPlaying[guild.id]=false;
 });
 
 log.alert("Starting bot");

--- a/config.json
+++ b/config.json
@@ -30,5 +30,6 @@
       "emergency": "cyan"
     }
   },
-  "padLog": "true"
+  "padLog": "true",
+  "bitrate": 48000
 }

--- a/config.json
+++ b/config.json
@@ -31,5 +31,5 @@
     }
   },
   "padLog": "true",
-  "bitrate": 48000
+  "bitrate": "96"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,7 @@
       "requires": {
         "long": "3.2.0",
         "prism-media": "0.0.1",
-        "snekfetch": "3.6.0",
+        "snekfetch": "3.6.1",
         "tweetnacl": "1.0.0",
         "ws": "3.3.2"
       },
@@ -448,9 +448,9 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "snekfetch": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/snekfetch/-/snekfetch-3.6.0.tgz",
-      "integrity": "sha512-QadgCNOxJzPdtZRwuSZi1egAoCFNpKE7iGQKguu70AyPKa6MRsXBGVX5qtxGG0QiZdN1y3DSEsnh5FXuoNeqeA=="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/snekfetch/-/snekfetch-3.6.1.tgz",
+      "integrity": "sha512-aLEvf1YR440pINb0LEo/SL2Q2s/A26+YEqPlx09A0XpGH7qWp8iqIFFolVILHn2yudWXJne9QWyQu+lzDp+ksQ=="
     },
     "sntp": {
       "version": "2.1.0",


### PR DESCRIPTION
CadenceBot no longer shares state between servers. Instead, state is stored in a set of associative arrays, mapping the appropriate ID (text channel, voice channel, server) to the state information - Therefore, the bot works on multiple servers, with one caveat:

Cadence itself rate-limits requests to one request every five minutes (300 seconds), per IP address. This is great for the web client, because requests are made through the browser, and therefore come from the user's IP. The problem @JakobFrank and I discovered while testing these changes is, requests made through CadenceBot come from the server hosting CadenceBot, and therefore come from that IP (18.221.243.54 for the live server at the moment). That means that, while @JakobFrank and I can make two separate requests within five minutes via the web client, my request blocks him from making one through CadenceBot for five minutes (because the bot's IP is ratelimited).
That, however, isn't really a problem I can fix, at least not by myself - @kenellorando, we should consider finding a workaround for this, as I don't think its expected behavior, or intended behavior. I suppose it might be possible to exempt the CadenceBot servers from ratelimits, but that might not be optimal. Maybe we could do that but have the bot handle limiting? But that grants multiple requests via different platforms.
I dunno. It's @kenellorando's call, as it is his server to manage.

-----

In addition to those changes, the bitrate CadenceBot streams at is now set as a config parameter, and is set to 96kbps (I think the default is 48). Hopefully, that should increase quality, and make @JakobFrank happ(y/ier).