### PR TITLE
Implement one step request

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -273,6 +273,7 @@ function command(message) {
             var msg={};
             msg.channel=message.channel;
             msg.guild=message.guild;
+            msg.client=message.client;
             msg.reply=function(r) {
                 log.notice("Mocked search returned:\n\n");
                 log.notice(r+"\n\n");

--- a/bot.js
+++ b/bot.js
@@ -391,6 +391,8 @@ bot.on('guildCreate', guild => {
 
 // Returns whether the two string parameters are the same-ish
 function caselessCompare (a, b) {
+    a=''+a;
+    b=''+b;
     return !a.localeCompare(b, "en-US", {
         "usage": "search",
         "sensitivity": "base",

--- a/bot.js
+++ b/bot.js
@@ -315,7 +315,9 @@ function command(message) {
 
                     // And restore lastSearchedSongs after a short delay (for the request to actually succeed)
                     setTimeout(function() {
+                        log.info("Restoring lastSearchedSongs...");
                         lastSearchedSongs[message.channel.id]=lSS;
+                        log.debug("lastSearchedSongs restored to:\n\n"+JSON.stringify(lastSearchedSongs[message.channel.id])+"\n\n")
                     }, 1000);
                 }
                 // For the moment, we don't know how to perform one-step request for this set of responses
@@ -323,6 +325,7 @@ function command(message) {
                     log.error("Could not perform one-step request for "+song);
                     if (lastSearchedSongs[message.channel.id].length==0) {
                         // For no results, assume the user meant to perform a normal (two-step) request
+                        log.info("Zero length results (assuming inadvertent request");
                         // (consider changing this later)
                         message.reply("Please request a number.");
 

--- a/bot.js
+++ b/bot.js
@@ -287,7 +287,7 @@ function command(message) {
                     request=oneStepRequestFilters[keys[i]](lastSearchedSongs[message.channel.id], song);
                     if (request) {
                         key=keys[i];
-                        log.notice(key+" chose song "+i);
+                        log.notice(key+" chose song "+request);
                         break;
                     }
                 }

--- a/bot.js
+++ b/bot.js
@@ -55,6 +55,27 @@ var reconnectTimeout=30; // Seconds
 
 var lastSearchedSongs={};
 
+// Defined later: Filters that one-step-request attempts to use to choose a song to request
+// Filters are queried one at a time, in order of appearance (by iterating over the keys)
+// They are stored as an associative array "name": filter, where the name will be used for logging
+// Each filter is a function, accepting an array of songs (the lastSearchedSongs entry for the current channel during one-step-request),
+//  and returning an integer (the number to pass to a mock request - one plus the index of the target song)
+// If the filter cannot choose a single song to request, it may return the subset of results which pass the filter
+//  The implementation should replace the array being searched with this subset
+// These filters should, however, come as late as reasonable, so as to not filter out results another filter would select unless these are incorrect
+// If the filter cannot choose a single song to request, but would not like to narrow the search space, it should return a falsy value (0).
+// If the implementation passes all filters without selecting a result,
+// It will present the remaining options to the user as if it was `search`, and have them choose a request normally (manual selection filter)
+var oneStepRequestFilters;
+// OK, so I sorta lied. The implementation does not currently support narrowing filters.
+// Attempting to use one will crash the bot.
+// This is because I can't think of a narrowing filter at the moment.
+// Once someone wants to implement it...
+// The implementation can be changed easily to support narrowing the array
+// But some refactoring will have to be done to allow a narrowed array to work with manual selection
+//  (as the prompt is saved from the mock search).
+// This will require refactoring the code for search result formatting into a helper function, and using it for the manual selection instead of the saved string.
+
 function command(message) {
     if (message.content===config.commands.play) {
         log.notice("Received play command.");

--- a/bot.js
+++ b/bot.js
@@ -280,13 +280,20 @@ function command(message) {
             // Delay one second to allow search to complete
             setTimeout(function() {
                 // Now, if lastSearchedSongs only contains one result (trivial case), set it to be requested
-                if (lastSearchedSongs[message.channel.id].length==1) {
+                var request=0;
+                var keys=Object.keys(oneStepRequestFilters);
+                for (var i=0; i<keys.length; ++i) {
+                    request=oneStepRequestFilters[keys[i]](lastSearchedSongs[message.channel.id]);
+                    if (request)
+                        break;
+                }
+                if (request>0) {
                     // Generate a mocked request call, now requesting the only result
                     var msg={};
                     msg.channel=message.channel;
                     msg.guild=message.guild;
                     msg.reply=function(r) { message.reply(r) };
-                    msg.content=config.commands.request+"1";
+                    msg.content=config.commands.request+request;
 
                     log.notice("Issuing mocked request command in server "+message.guild.name+"...\n");
                     command(msg);
@@ -377,6 +384,15 @@ bot.on('message', message => {
 bot.on('guildCreate', guild => {
     isPlaying[guild.id]=false;
 });
+
+oneStepRequestFilters={
+    "trivial-filter": function(songs) {
+        if (songs.length==1)
+            return 1;
+        else
+            return 0;
+    }
+}
 
 log.alert("Starting bot");
 

--- a/bot.js
+++ b/bot.js
@@ -270,8 +270,10 @@ function command(message) {
                     // Now that the song has been requested, log our success in one-step request
                     log.notice("Successfully performed one-step request for: "+song);
 
-                    // And restore lastSearchedSongs
-                    lastSearchedSongs[message.channel.id]=lSS;
+                    // And restore lastSearchedSongs after a short delay (for the request to actually succeed)
+                    setTimeout(function() {
+                        lastSearchedSongs[message.channel.id]=lSS;
+                    }, 1000);
                 }
                 // For the moment, we don't know how to perform one-step request for multiple responses.
                 else {

--- a/bot.js
+++ b/bot.js
@@ -449,6 +449,25 @@ oneStepRequestFilters={
             }
         }
         return result;
+    },
+    "artist+title-filter": function(songs, request) {
+        var result=0;
+        var condition=function(req, title, artist) {
+            req=''+req;
+            title=''+title;
+            artist=''+artist;
+            return caselessCompare(req.substring(0, artist.length), artist)
+                && caselessCompare(req.substring(req.length-title.length), title);
+        };
+        for (var i=0; i<songs.length; ++i) {
+            if (condition(request, songs[i].title, songs[i].artist)) {
+                if (result) { // Non-unique result
+                    return 0;
+                }
+                result=i+1;
+            }
+        }
+        return result;
     }
 }
 

--- a/bot.js
+++ b/bot.js
@@ -430,6 +430,25 @@ oneStepRequestFilters={
             }
         }
         return result;
+    },
+    "title+artist-filter": function(songs, request) {
+        var result=0;
+        var condition=function(req, title, artist) {
+            req=''+req;
+            title=''+title;
+            artist=''+artist;
+            return caselessCompare(req.substring(0, title.length), title)
+                && caselessCompare(req.substring(req.length-artist.length), artist);
+        };
+        for (var i=0; i<songs.length; ++i) {
+            if (condition(request, songs[i].title, songs[i].artist)) {
+                if (result) { // Non-unique result
+                    return 0;
+                }
+                result=i+1;
+            }
+        }
+        return result;
     }
 }
 

--- a/bot.js
+++ b/bot.js
@@ -231,8 +231,15 @@ function command(message) {
                    for (var i=0; i<songs.length; ++i) {
                        response+="  "+(i+1)+")  \""+songs[i].title+"\" by "+songs[i].artist[0]+"\n";
                    }
-                   log.debug("Issuing response:\n\n"+response+"\n\n");
-                   message.reply(response);
+                   if ((response+message.client.user.tag).length>2000) {
+                       log.info("Message length was longer than 2000. Could not send.");
+                       message.reply("That query had "+songs.length+" results.\n\n"+
+                       "Unfortunately, that means that search term was too broad. Please narrow it down and try again.");
+                   }
+                   else {
+                       log.debug("Issuing response:\n\n"+response+"\n\n");
+                       message.reply(response);
+                   }
                }
            }
            else {
@@ -322,8 +329,17 @@ function command(message) {
                         lastSearchedSongs[message.channel.id]=lSS;
                     }
                     else {
-                        message.reply("I'm sorry, I couldn't discriminate between "+lastSearchedSongs[message.channel.id].length+" songs.\n\n"+
-                                      "Please run \""+config.commands.request+"\" with the number of the song you'd like to request.\n\n"+response);
+                        string="I'm sorry, I couldn't discriminate between "+lastSearchedSongs[message.channel.id].length+" songs.\n\n"+
+                                      "Please run \""+config.commands.request+"\" with the number of the song you'd like to request.\n\n"+response;
+                        if ((string+message.client.user.tag).length>2000) {
+                            log.notice("Message length longer than 2000. Could not issue response.");
+                            message.reply("Sorry, I couldn't discriminate between "+lastSearchedSongs[message.channel.id].length+" songs, and that search term was too broad for me to display the results.\n\n"+
+                                "Please narrow your search term and try again.");
+                        }
+                        else {
+                            log.debug("Issuing response:\n\n"+string+"\n\n");
+                            message.reply(string);
+                        }
                         // Since we instruct the user to use lastSearchedSongs, we overwrite the old copy.
                     }
                 }

--- a/bot.js
+++ b/bot.js
@@ -416,6 +416,18 @@ oneStepRequestFilters={
             }
         }
         return result;
+    },
+    "artist-filter": function(songs, request) {
+        var result=0;
+        for (var i=0; i<songs.length; ++i) {
+            if (caselessCompare(songs[i].artist, request)) {
+                if (result) { // Non-unique result
+                    return 0;
+                }
+                result=i+1;
+            }
+        }
+        return result;
     }
 }
 

--- a/bot.js
+++ b/bot.js
@@ -97,7 +97,7 @@ function command(message) {
                         var msg={};
                         msg.content=config.commands.nowplaying;
                         msg.reply=function (s) {log.debug("Sent message: "+s)};
-                        log.notice("Sending false nowplaying command in server "+message.guild.name+"...");
+                        log.notice("Sending false nowplaying command in server "+message.guild.name+"...\n");
                         command(msg);
 
                         // Now, we want to reissue ourselves a play command
@@ -122,7 +122,7 @@ function command(message) {
                         msg.member={};
                         msg.member.voiceChannel=voiceChannel;
                         msg.guild=message.guild;
-                        log.notice("Sending mocked play command in server "+message.guild.name+"...");
+                        log.notice("Sending mocked play command in server "+message.guild.name+"...\n");
                         command(msg);
                     });
                 }).catch(err => log.critical(err));
@@ -253,6 +253,7 @@ function command(message) {
             msg.content=config.commands.search+song;
             lSS=lastSearchedSongs[message.channel.id].slice();
 
+            log.notice("Issuing mocked search command in server "+message.guild.name+"...\n");
             command(msg);
 
             // Delay one second to allow search to complete
@@ -265,6 +266,8 @@ function command(message) {
                     msg.guild=message.guild;
                     msg.reply=function(r) { message.reply(r) };
                     msg.content=config.commands.request+"1";
+
+                    log.notice("Issuing mocked request command in server "+message.guild.name+"...\n");
                     command(msg);
 
                     // Now that the song has been requested, log our success in one-step request

--- a/bot.js
+++ b/bot.js
@@ -269,7 +269,7 @@ function command(message) {
             log.warning(song+" is not a number. Attempting one-step request.");
 
             // First, perform a mocked search, backing up lastSearchedSongs and saving the result string
-            var response;
+            var response=false;
             var msg={};
             msg.channel=message.channel;
             msg.guild=message.guild;
@@ -278,6 +278,10 @@ function command(message) {
                 log.notice("Mocked search returned:\n\n");
                 log.notice(r+"\n\n");
                 response=r;
+                // Make response false if we have no results, to avoid bugs later
+                if (response.includes("no results")) {
+                    response=false;
+                }
             };
             msg.content=config.commands.search+song;
             lSS=lastSearchedSongs[message.channel.id].slice();
@@ -323,7 +327,7 @@ function command(message) {
                 // For the moment, we don't know how to perform one-step request for this set of responses
                 else {
                     log.error("Could not perform one-step request for "+song);
-                    if (lastSearchedSongs[message.channel.id].length==0) {
+                    if (lastSearchedSongs[message.channel.id].length==0 || !response) {
                         // For no results, assume the user meant to perform a normal (two-step) request
                         log.info("Zero length results (assuming inadvertent request");
                         // (consider changing this later)

--- a/bot.js
+++ b/bot.js
@@ -279,16 +279,20 @@ function command(message) {
 
             // Delay one second to allow search to complete
             setTimeout(function() {
-                // Now, if lastSearchedSongs only contains one result (trivial case), set it to be requested
+                // Now, if any filter can select one song out of lastSearchedSongs, request it.
                 var request=0;
                 var keys=Object.keys(oneStepRequestFilters);
+                var key;
                 for (var i=0; i<keys.length; ++i) {
                     request=oneStepRequestFilters[keys[i]](lastSearchedSongs[message.channel.id]);
-                    if (request)
+                    if (request) {
+                        key=keys[i];
+                        log.notice(key+" chose song "+i);
                         break;
+                    }
                 }
                 if (request>0) {
-                    // Generate a mocked request call, now requesting the only result
+                    // Generate a mocked request call, now requesting the filter's result
                     var msg={};
                     msg.channel=message.channel;
                     msg.guild=message.guild;
@@ -299,14 +303,14 @@ function command(message) {
                     command(msg);
 
                     // Now that the song has been requested, log our success in one-step request
-                    log.notice("Successfully performed one-step request for: "+song);
+                    log.notice("Successfully performed one-step request for: "+song+" using the \""+key+"\" filter.");
 
                     // And restore lastSearchedSongs after a short delay (for the request to actually succeed)
                     setTimeout(function() {
                         lastSearchedSongs[message.channel.id]=lSS;
                     }, 1000);
                 }
-                // For the moment, we don't know how to perform one-step request for multiple responses.
+                // For the moment, we don't know how to perform one-step request for this set of responses
                 else {
                     log.error("Could not perform one-step request for "+song);
                     if (lastSearchedSongs[message.channel.id].length==0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "ajv": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
-      "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
@@ -224,7 +224,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.1",
+        "ajv": "5.5.2",
         "har-schema": "2.0.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,6 +171,13 @@
         "iconv-lite": "0.4.19"
       }
     },
+    "erlpack": {
+      "version": "github:hammerandchisel/erlpack#674ebfd3439ba4b7ce616709821d27630f7cdc61",
+      "requires": {
+        "bindings": "1.2.1",
+        "nan": "2.8.0"
+      }
+    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -309,6 +316,19 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "libsodium": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.5.4.tgz",
+      "integrity": "sha512-s1TQ2V23JvGby1gnCQEQncTNTGck/rtJPPA8c0TiBo9z9TpT4eUk5zThte8H1TkdoKQznneqZqyoqdrwu2btWw=="
+    },
+    "libsodium-wrappers": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.5.4.tgz",
+      "integrity": "sha512-dAYsfQgh6XwR4I65y7T5qDgb2XNKDpzXEXz229sDplaJfnAuIBTHBYlQ44jL5DIS4cCUspE3+g0kF4/Xe8286A==",
+      "requires": {
+        "libsodium": "0.5.4"
       }
     },
     "long": {
@@ -520,6 +540,11 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
+    "uws": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/uws/-/uws-0.14.5.tgz",
+      "integrity": "sha1-Z6rzPEaypYel9mZtAPdpEyjxSdw="
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -538,6 +563,14 @@
         "async-limiter": "1.0.0",
         "safe-buffer": "5.1.1",
         "ultron": "1.1.1"
+      }
+    },
+    "zlib-sync": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/zlib-sync/-/zlib-sync-0.1.4.tgz",
+      "integrity": "sha512-DRy+RONKzy/J6skNmq8ZBXtVAIoB4qbun+FCChlSlEvF7s9LJ0wzUXjVwl4tQ/jYT8V+LPzCg/sTcRj4E0g0fQ==",
+      "requires": {
+        "nan": "2.8.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,7 +151,7 @@
         "prism-media": "0.0.1",
         "snekfetch": "3.6.1",
         "tweetnacl": "1.0.0",
-        "ws": "3.3.2"
+        "ws": "3.3.3"
       }
     },
     "ecc-jsbn": {
@@ -531,9 +531,9 @@
       }
     },
     "ws": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.2.tgz",
-      "integrity": "sha512-t+WGpsNxhMR4v6EClXS8r8km5ZljKJzyGhJf7goJz9k5Ye3+b5Bvno5rjqPuIBn5mnn5GBb7o8IrIWHxX1qOLQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
         "async-limiter": "1.0.0",
         "safe-buffer": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,13 @@
   },
   "dependencies": {
     "discord.js": "^11.2.1",
+    "erlpack": "github:hammerandchisel/erlpack",
     "js-logging": "^0.1.0",
+    "libsodium-wrappers": "^0.5.4",
     "node-fetch": "^1.7.3",
     "node-opus": "^0.2.7",
-    "request": "^2.83.0"
+    "request": "^2.83.0",
+    "uws": "^0.14.5",
+    "zlib-sync": "^0.1.4"
   }
 }

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,11 @@
 
 npm install --save js-logging
 npm install --save discord.js
+npm install --save zlib-sync
+npm install --save libsodium-wrappers@^0.5.4
+npm install --save uws@^0.14.5
 npm install --save node-fetch
 npm install --save request
 npm install --save node-opus
+npm install --save erlpack@hammerandchisel/erlpack
 


### PR DESCRIPTION
The new one-step-request functionality allows users to request a song in one step (as implied by the name), simply passing the string they'd search for to `Cadence request`. CadenceBot will attempt to choose a song to request from the search results using five filters, in order:

1. Trivial case (If Cadence returns a single result, choose it)
2. Title case (If exactly one result has a title which exactly matches the request, choose it)
3. Artist case (If exactly one result has an artist which exactly matches the request, choose it)
4. Title+artist case (If exactly one result has a title which exactly matches the beginning of the result, and an artist which exactly matches the end of the result, regardless of text in between, choose it)
5. Artist+title case (If exactly one result has an artist which exactly matches the beginning of the result, and a title which exactly matches the end of the result, regardless of text in between, choose it)

All comparisons done ignoring case, accents, and punctuation.

If these filters fail to choose a result, then the results are presented to the user as if returned by search and the user may request one via a normal second-step request.

This pull request is done with regards to #11.