### PR TITLE
Add a currently playing status message

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -458,7 +458,7 @@ function updatePresence() {
             text=text.substring("parseMusic(".length, text.length-2);
             var json=JSON.parse(text);
             bot.user.setPresence({ game:
-                                     { name: "\""+json['/cadence1']['artist_name'].trim()+"\" by "+json['/cadence1']['song_title'].trim() }
+                                     { name: "\""+json['/cadence1']['song_title'].trim()+"\" by "+json['/cadence1']['artist_name'].trim() }
             });
             bot.setTimeout(updatePresence, 10000);
         });

--- a/bot.js
+++ b/bot.js
@@ -453,6 +453,12 @@ bot.on('guildCreate', guild => {
 });
 
 function updatePresence() {
+    // Allow disable of presence feature
+    // (also preventing crashes from bad interval settings
+    if (config.statusUpdateIntervalMs<0) {
+        return;
+    }
+
     fetch('http://cadenceradio.com:8000/now-playing.xsl').then(response => {
         response.text().then(text => {
             text=text.substring("parseMusic(".length, text.length-2);

--- a/bot.js
+++ b/bot.js
@@ -460,7 +460,7 @@ function updatePresence() {
             bot.user.setPresence({ game:
                                      { name: "\""+json['/cadence1']['song_title'].trim()+"\" by "+json['/cadence1']['artist_name'].trim() }
             });
-            bot.setTimeout(updatePresence, 10000);
+            bot.setTimeout(updatePresence, config.statusUpdateIntervalMs);
         });
     });
 }

--- a/bot.js
+++ b/bot.js
@@ -456,6 +456,9 @@ function updatePresence() {
     // Allow disable of presence feature
     // (also preventing crashes from bad interval settings
     if (config.statusUpdateIntervalMs<0) {
+        bot.user.setPresence({ game:
+                                 { name: "Cadence Radio" }
+        });
         return;
     }
 

--- a/bot.js
+++ b/bot.js
@@ -452,6 +452,21 @@ bot.on('guildCreate', guild => {
     isPlaying[guild.id]=false;
 });
 
+function updatePresence() {
+    fetch('http://cadenceradio.com:8000/now-playing.xsl').then(response => {
+        response.text().then(text => {
+            text=text.substring("parseMusic(".length, text.length-2);
+            var json=JSON.parse(text);
+            bot.user.setPresence({ game:
+                                     { name: "\""+json['/cadence1']['artist_name'].trim()+"\" by "+json['/cadence1']['song_title'].trim() }
+            });
+            bot.setTimeout(updatePresence, 10000);
+        });
+    });
+}
+
+bot.on('ready', updatePresence);
+
 // Returns whether the two string parameters are the same-ish
 function caselessCompare (a, b) {
     a=''+a;

--- a/default-config.json
+++ b/default-config.json
@@ -33,5 +33,5 @@
   "padLog": "true",
   "bitrate": "96",
   "roundtripDelayMs": 500,
-  "statusUpdateIntervalMs": 10000
+  "statusUpdateIntervalMs": 3000
 }

--- a/default-config.json
+++ b/default-config.json
@@ -32,5 +32,6 @@
   },
   "padLog": "true",
   "bitrate": "96",
-  "roundtripDelayMs": 500
+  "roundtripDelayMs": 500,
+  "statusUpdateIntervalMs": 10000
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -181,6 +181,13 @@
         "iconv-lite": "0.4.19"
       }
     },
+    "erlpack": {
+      "version": "github:hammerandchisel/erlpack#674ebfd3439ba4b7ce616709821d27630f7cdc61",
+      "requires": {
+        "bindings": "1.2.1",
+        "nan": "2.8.0"
+      }
+    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "CadenceBot",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -179,13 +179,6 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
         "iconv-lite": "0.4.19"
-      }
-    },
-    "erlpack": {
-      "version": "github:hammerandchisel/erlpack#674ebfd3439ba4b7ce616709821d27630f7cdc61",
-      "requires": {
-        "bindings": "1.2.1",
-        "nan": "2.8.0"
       }
     },
     "extend": {


### PR DESCRIPTION
At a configurable interval, the bot will poll the Cadence server for the currently playing song, and assign that information to its status. This is a feature requested by @kenellorando.

If desired, this feature can be disabled entirely by setting the interval to a negative number in `config.json`. This will set the status message to 'Playing **Cadence Radio**' or something similar (as the details are provided by Discord).