### PR TITLE
Change reply message for voice channel joining

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -179,7 +179,7 @@ function command(message) {
             }
             else {
                 log.error("User "+message.member.user.tag+" is not in a voice channel in server "+message.guild.name+".");
-                message.reply("You need to be in a voice channel for me to play Cadence in it, silly!");
+                message.reply("You need to be in a voice channel for me to play Cadence in it, この馬鹿!");
             }
         }
     }


### PR DESCRIPTION
This pull request enhances the reply message CadenceBot says when asked to join a voice channel when the person asking is not in a voice channel. This response better suits the personality of Cadence.