### PR TITLE
Detailed helptext framework

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -657,6 +657,7 @@ function command(message) {
             message.reply("OK, OK, I get it, you don't like me, sheesh!");
         }
     } else if (message.content === config.commands.help) {
+        // Summary helptext.
         log.notice("Received help command.");
         var help = "";
         help =
@@ -682,6 +683,24 @@ function command(message) {
         }
         message.reply(help);
         log.notice("Issued help message.");
+    } else if (message.content.startsWith(config.commands.help) + " ") {
+        // Per-command helptext.
+        log.notice("Received help-for-command command.");
+        const target = message.content.substring(config.commands.search.length);
+        log.info("Help is for command: " + target);
+        if (Object.keys(config.commandDetails).includes(target)) {
+        } else {
+            log.info("Command not recognized.");
+            message.reply(
+                "I'm sorry, I don't have anything to tell you about the " +
+                    target +
+                    " command. Are you sure that's something I can do?\n\n" +
+                    "See " +
+                    config.commands.help +
+                    " for more information about what commands I support."
+            );
+            log.notice("Issued command-unrecognized message.");
+        }
     } else if (message.content === config.commands.nowplaying) {
         log.notice("Received nowplaying command.");
         const url = config.API.stream.prefix + config.API.stream.nowplaying;

--- a/bot.js
+++ b/bot.js
@@ -686,7 +686,9 @@ function command(message) {
     } else if (message.content.startsWith(config.commands.help) + " ") {
         // Per-command helptext.
         log.notice("Received help-for-command command.");
-        const target = message.content.substring(config.commands.search.length);
+        const target = message.content.substring(
+            config.commands.help.length + 1
+        );
         log.info("Help is for command: " + target);
         if (Object.keys(config.commandDetails).includes(target)) {
             const detailsObject = config.commandDetails[target];

--- a/bot.js
+++ b/bot.js
@@ -683,7 +683,7 @@ function command(message) {
         }
         message.reply(help);
         log.notice("Issued help message.");
-    } else if (message.content.startsWith(config.commands.help) + " ") {
+    } else if (message.content.startsWith(config.commands.help + " ")) {
         // Per-command helptext.
         log.notice("Received help-for-command command.");
         const target = message.content.substring(

--- a/bot.js
+++ b/bot.js
@@ -702,10 +702,12 @@ function command(message) {
                         target +
                         " does not include an internalKey!"
                 );
-                response = "# The " + target + " command\n\n";
+                response = "**The " + target + " command**\n\n";
             } else {
                 response =
-                    "# " + config.commands[detailsObject.internalKey] + "\n\n";
+                    "**" +
+                    config.commands[detailsObject.internalKey] +
+                    "**\n\n";
             }
 
             // Now, the subtitle.
@@ -717,7 +719,7 @@ function command(message) {
                         " does not include a subtitle!"
                 );
             } else {
-                response += "## " + detailsObject.subtitle + "\n\n";
+                response += "> " + detailsObject.subtitle + "\n\n";
             }
 
             // And finally, the body.

--- a/bot.js
+++ b/bot.js
@@ -702,10 +702,12 @@ function command(message) {
                         target +
                         " does not include an internalKey!"
                 );
-                response = "**The " + target + " command**\n";
+                response = "> **The " + target + " command**\n";
             } else {
                 response =
-                    "**" + config.commands[detailsObject.internalKey] + "**\n";
+                    "> **" +
+                    config.commands[detailsObject.internalKey] +
+                    "**\n";
             }
 
             // Now, the subtitle.
@@ -717,7 +719,7 @@ function command(message) {
                         " does not include a subtitle!"
                 );
             } else {
-                response += "> " + detailsObject.subtitle + "\n\n";
+                response += "> " + detailsObject.subtitle + "\n> \n";
             }
 
             // And finally, the body.
@@ -728,9 +730,9 @@ function command(message) {
                         target +
                         " does not include a lines array!"
                 );
-                response += "I don't really have anything to say here.";
+                response += "> I don't really have anything to say here.";
             } else {
-                response += detailsObject.lines.join("\n");
+                response += detailsObject.lines.map(x => "> " + x).join("\n");
             }
 
             // Now send the response.

--- a/bot.js
+++ b/bot.js
@@ -762,7 +762,7 @@ function command(message) {
                                     )
                                 ) {
                                     // Then add the command's trigger phrase to result
-                                    result += config.commands[firstWord];
+                                    result += config.commands[firstWord].trim();
                                 } else {
                                     // Otherwise, add firstWord back in with its % restored
                                     result += "%" + firstWord;

--- a/bot.js
+++ b/bot.js
@@ -702,12 +702,10 @@ function command(message) {
                         target +
                         " does not include an internalKey!"
                 );
-                response = "**The " + target + " command**\n\n";
+                response = "**The " + target + " command**\n";
             } else {
                 response =
-                    "**" +
-                    config.commands[detailsObject.internalKey] +
-                    "**\n\n";
+                    "**" + config.commands[detailsObject.internalKey] + "**\n";
             }
 
             // Now, the subtitle.

--- a/bot.js
+++ b/bot.js
@@ -734,7 +734,7 @@ function command(message) {
             }
 
             // Now send the response.
-            message.reply(response);
+            sendLongMessage(message.channel, response);
             log.notice("Issued generated helptext.");
             log.debug("Generated helptext message was:\n" + response);
         } else {

--- a/bot.js
+++ b/bot.js
@@ -689,6 +689,52 @@ function command(message) {
         const target = message.content.substring(config.commands.search.length);
         log.info("Help is for command: " + target);
         if (Object.keys(config.commandDetails).includes(target)) {
+            const detailsObject = config.commandDetails[target];
+            let response;
+
+            // Assemble a title using the configured 'trigger phrase' for the command
+            if (detailsObject.internalKey == null) {
+                // If we haven't been told how to, log an error and use the passed key instead.
+                log.error(
+                    "Detailed helptext spec for command " +
+                        target +
+                        " does not include an internalKey!"
+                );
+                response = "# The " + target + " command\n\n";
+            } else {
+                response =
+                    "# " + config.commands[detailsObject.internalKey] + "\n\n";
+            }
+
+            // Now, the subtitle.
+            if (detailsObject.subtitle == null) {
+                // If there is no subtitle, log a warning.
+                log.warning(
+                    "Detailed helptext spec for command " +
+                        target +
+                        " does not include a subtitle!"
+                );
+            } else {
+                response += "## " + detailsObject.subtitle + "\n\n";
+            }
+
+            // And finally, the body.
+            if (detailsObject.lines == null) {
+                // If there is no body, log an error.
+                log.error(
+                    "Detailed helptext spec for command " +
+                        target +
+                        " does not include a lines array!"
+                );
+                response += "I don't really have anything to say here.";
+            } else {
+                response += detailsObject.lines.join("\n");
+            }
+
+            // Now send the response.
+            message.reply(response);
+            log.notice("Issued generated helptext.");
+            log.debug("Generated helptext message was:\n" + response);
         } else {
             log.info("Command not recognized.");
             message.reply(

--- a/bot.js
+++ b/bot.js
@@ -718,6 +718,7 @@ function command(message) {
                         target +
                         " does not include a subtitle!"
                 );
+                response += "> \n";
             } else {
                 response += "> " + detailsObject.subtitle + "\n> \n";
             }

--- a/default-config.json
+++ b/default-config.json
@@ -39,8 +39,8 @@
       "subtitle": "The help command provides information to assist with the usage of Cadence.",
       "lines": [
         "It can be used in one of two ways:",
-        " 1. Without any argument, it will generate a summary of commands and a brief snippet of their purpose.",
-        " 2. Provided the name of a command, it will provide details regarding the specific usage of that command - Such as this message."
+        "    1. Without any argument, it will generate a summary of commands and a brief snippet of their purpose.",
+        "    2. Provided the name of a command, it will provide details regarding the specific usage of that command - Such as this message."
       ]
     }
   },

--- a/default-config.json
+++ b/default-config.json
@@ -39,8 +39,8 @@
       "subtitle": "The help command provides information to assist with the usage of Cadence.",
       "lines": [
         "It can be used in one of two ways:",
-        "    1. Without any argument, it will generate a summary of commands and a brief snippet of their purpose.",
-        "    2. Provided the name of a command, it will provide details regarding the specific usage of that command - Such as this message."
+        "    1. Without any argument (%help), it will generate a summary of commands and a brief snippet of their purpose.",
+        "    2. Provided the name of a command (%help help), it will provide details regarding the specific usage of that command."
       ]
     }
   },

--- a/default-config.json
+++ b/default-config.json
@@ -39,8 +39,8 @@
       "subtitle": "The help command provides information to assist with the usage of Cadence.",
       "lines": [
         "It can be used in one of two ways:",
-        "    1. Without any argument (%help), it will generate a summary of commands and a brief snippet of their purpose.",
-        "    2. Provided the name of a command (%help help), it will provide details regarding the specific usage of that command."
+        "    1. Without any argument (`%help`), it will generate a summary of commands and a brief snippet of their purpose.",
+        "    2. Provided the name of a command (`%help help`), it will provide details regarding the specific usage of that command."
       ]
     }
   },

--- a/default-config.json
+++ b/default-config.json
@@ -33,6 +33,17 @@
       "description": "Request a list of songs in the Cadence database"
     }
   },
+  "commandDetails": {
+    "help": {
+      "internalKey": "help",
+      "subtitle": "The help command provides information to assist with the usage of Cadence.",
+      "lines": [
+        "It can be used in one of two ways:",
+        " 1. Without any argument, it will generate a summary of commands and a brief snippet of their purpose.",
+        " 2. Provided the name of a command, it will provide details regarding the specific usage of that command - Such as this message."
+      ]
+    }
+  },
   "customCommands": {
     "equalTo": {
       "Cadence introduce yourself": {


### PR DESCRIPTION
Add the code required to generate and send a detailed helptext message, along with the config for the detailed helptext for the help command.

Usage:
![image](https://user-images.githubusercontent.com/15851480/103469270-511fc800-4d28-11eb-94ec-cb6c615a12ad.png)


