### PR TITLE
Separate help (summary) and help-for-topic

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -683,7 +683,7 @@ function command(message) {
         }
         message.reply(help);
         log.notice("Issued help message.");
-    } else if (message.content.startsWith(config.commands.help + " ")) {
+    } else if (message.content.startsWith(config.commands.helpTopic)) {
         // Per-command helptext.
         log.notice("Received help-for-command command.");
         const target = message.content.substring(

--- a/bot.js
+++ b/bot.js
@@ -687,7 +687,7 @@ function command(message) {
         // Per-command helptext.
         log.notice("Received help-for-command command.");
         const target = message.content.substring(
-            config.commands.help.length + 1
+            config.commands.helpTopic.length
         );
         log.info("Help is for command: " + target);
         if (Object.keys(config.helpTopics).includes(target)) {

--- a/default-config.json
+++ b/default-config.json
@@ -3,6 +3,7 @@
     "play": "Cadence play",
     "stop": "Cadence stop",
     "help": "Cadence help",
+    "helpTopic": "Cadence help ",
     "nowplaying": "Cadence now playing",
     "search": "Cadence search ",
     "request": "Cadence request ",

--- a/default-config.json
+++ b/default-config.json
@@ -41,14 +41,14 @@
       "lines": [
         "It can be used in one of two ways:",
         "    1. Without any argument (`%help`), it will generate a summary of commands and a brief snippet of their purpose.",
-        "    2. Provided the name of a command (`%help help`), it will provide details regarding the specific usage of that command."
+        "    2. Provided the name of a command (`%helpTopic help`), it will provide details regarding the specific usage of that command."
       ]
     },
     "bans": {
       "title": "Banning and CadenceBot",
       "subtitle": "Access control for CadenceBot commands.",
       "lines": [
-        "CadenceBot allows for the instance-wide administrator (See `%help admin`) to ban and unban users at their discretion.",
+        "CadenceBot allows for the instance-wide administrator (See `%helpTopic admin`) to ban and unban users at their discretion.",
         "Banned users will be ignored entirely by CadenceBot - No message they send will be examined for containing a command.",
         "Bans may either be permanent, or may only take place within a time window (between two specific moments, or up until a certain time).",
         "",

--- a/default-config.json
+++ b/default-config.json
@@ -19,6 +19,10 @@
     "help": {
       "description": "Generates this help message"
     },
+    "helpTopic": {
+      "description": "Displays additional help information for a chosen <topic>.",
+      "parameters": ["topic"]
+    },
     "nowplaying": {
       "description": "Displays now playing information from Cadence"
     },


### PR DESCRIPTION
This separates these two commands semantically from a code perspective, without doing so from a user perspective. I had originally intended to do this near the end of the project, but recent confusion surrounding the command has lead me to believe I should do otherwise.

This is the first new primary command added since March 17, 2019, in 319692aff356a5e1df5970a49923b7729a12290f.

Summary helptext with the new primary command:
![image](https://user-images.githubusercontent.com/15851480/103957138-a9334180-510f-11eb-88d5-6e4d17248246.png)

Detailed helptext for help, with helpTopic reconfigured to illustrate separation of commands:
![image](https://user-images.githubusercontent.com/15851480/103957171-c23bf280-510f-11eb-9de8-df58857633b3.png)

This PR fixes #67 .