### PR TITLE
Custom command weighting

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -266,7 +266,18 @@ function sendLongMessage(channel, text, length = 2000) {
 }
 
 function selectOne(array) {
-    return array[Math.round(Math.random() * (array.length - 1))];
+    // First, 'cook' array into a flat list of strings
+    // (allowing for the {option: '', weight: <n>} syntax)
+    const options = array.flatMap(option => {
+        // A plain string is returned intact
+        if (typeof option === "string") return option;
+
+        // Assume if we don't have a string we have an object with the above syntax.
+        return new Array(option.weight).fill(option.option);
+    });
+
+    // Now choose out of the remaining options.
+    return options[Math.round(Math.random() * (options.length - 1))];
 }
 
 // Does the leg work of choosing a voice channel for play to default to

--- a/default-config.json
+++ b/default-config.json
@@ -124,24 +124,14 @@
     "multitargeted": {
         "Cadence resolve the debate between ": {
             "random": [
-                "%u0 is right, %u1 is wrong.",
-                "%u1 is right, %u0 is wrong.",
-                "%u0 is right, %u1 is wrong.",
-                "%u1 is right, %u0 is wrong.",
-                "%u0 is right, %u1 is wrong.",
-                "%u1 is right, %u0 is wrong.",
-                "%u0 is right, %u1 is wrong.",
-                "%u1 is right, %u0 is wrong.",
-                "%u0 is right, %u1 is wrong.",
-                "%u1 is right, %u0 is wrong.",
-                "%u0 is right, %u1 is wrong.",
-                "%u1 is right, %u0 is wrong.",
-                "%u0 is right, %u1 is wrong.",
-                "%u1 is right, %u0 is wrong.",
-                "%u0 is right, %u1 is wrong.",
-                "%u1 is right, %u0 is wrong.",
-                "%u0 is right, %u1 is wrong.",
-                "%u1 is right, %u0 is wrong.",
+                {
+                  "option": "%u0 is right, %u1 is wrong.",
+                  "weight": 10
+                },
+                {
+                  "option": "%u1 is right, %u0 is wrong.",
+                  "weight": 10
+                },
                 "%u1 is a moron, %u0 is right.",
                 "%u1 is right, %u0 is a moron."
             ],
@@ -163,25 +153,23 @@
       },
       "Cadence don't say ": {
         "random": [
+            {
+              "option": "Ok.",
+              "weight": 5
+            },
+            {
+              "option": "Okay.",
+              "weight": 4
+            },
+            {
+              "option": "Fine.",
+              "weight": 4
+            },
+            {
+              "option": "If you insist, just this once.",
+              "weight": 4
+            },
             "Don't tell me what to do. \" %s\"",
-            "Ok.",
-            "Ok.",
-            "Ok.",
-            "Ok.",
-            "Ok.",
-            "Okay.",
-            "Okay.",
-            "Okay.",
-            "Okay.",
-            "Okay.",
-            "Fine.",
-            "Fine.",
-            "Fine.",
-            "Fine.",
-            "If you insist, just this once.",
-            "If you insist, just this once.",
-            "If you insist, just this once.",
-            "If you insist, just this once.",
             "Fine, I won't say \" %s\" for a while. Starting now..."
         ]
       }

--- a/default-config.json
+++ b/default-config.json
@@ -159,7 +159,7 @@
             },
             {
               "option": "Okay.",
-              "weight": 4
+              "weight": 5
             },
             {
               "option": "Fine.",


### PR DESCRIPTION
This pull request allows random options to custom commands to be set as objects which specify both the option and an integer weight. selectOne will automatically expand such an object into it's equivalent - `weight` repetitions of the option.

Merging this PR fixes #82 .