### PR TITLE
Allow disabling of core command aliases

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -443,6 +443,9 @@ function coreAliasTranslation(content) {
 
     // Iterate over all aliases we recognize.
     for (const alias of config.commandAliases) {
+        // Skip this alias if it is disabled.
+        if (alias.disabled) continue;
+
         // If this alias is a prefix-match...
         if (alias.prefix) {
             // And our message starts with the alias text...


### PR DESCRIPTION
This cannot apply to config overrides with current implementation, but I'm providing it for consistency (we can disable things like custom commands) - It currently only really has use in documentation, but perhaps I should require that these get unique keys so that they can be disabled or modified in config overrides properly.